### PR TITLE
[RFC] Put data to ElasticSearch

### DIFF
--- a/QuestionApp/AndroidManifest.xml
+++ b/QuestionApp/AndroidManifest.xml
@@ -8,6 +8,8 @@
         android:minSdkVersion="17"
         android:targetSdkVersion="21" />
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
@@ -1,9 +1,7 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.data;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import android.content.Context;
@@ -34,7 +32,7 @@ public class DataManager {
 	private DataManager(Context context){
 		this.clientData = new ClientData(context);
 		this.localDataStore = new LocalDataStore(context);
-		this.remoteDataStore = new RemoteDataStore();
+		this.remoteDataStore = new RemoteDataStore(context);
 		this.pushOnline = new ArrayList<UUID>();
 		this.upVoteOnline = new ArrayList<UUID>();
 	}

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/RemoteDataStore.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/RemoteDataStore.java
@@ -23,29 +23,53 @@ import com.google.gson.reflect.TypeToken;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer.AnswerDeserializer;
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer.AnswerSerializer;
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer.CommentDeserializer;
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer.CommentSerializer;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer.QuestionDeserializer;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer.QuestionSerializer;
 
+/**
+ * A data store that uses an ElasticSearch server as a data storage mechanism.
+ */
 public class RemoteDataStore implements IDataStore {
 
 	protected static String ES_BASE_URL = "http://cmput301.softwareprocess.es:8080/cmput301f14t14/";
 	private static final String QUESTION_PATH = "question/";
+	private static final String ANSWER_PATH = "answer/";
+	private static final String QUESTION_COMMENT_PATH = "qcomment/";
+	private static final String ANSWER_COMMENT_PATH = "acomment/";
 	private static final String TAG = "RemoteDataStore";
 
 	private Gson gson;
-	
+
 	public RemoteDataStore() {
 		GsonBuilder gb = new GsonBuilder();
+		// Register serializers and deserializers
+		// Note: The comment stuff is ugly, but it should work
 		gb.registerTypeAdapter(Question.class, new QuestionSerializer());
 		gb.registerTypeAdapter(Question.class, new QuestionDeserializer());
+		gb.registerTypeAdapter(Answer.class, new AnswerSerializer());
+		gb.registerTypeAdapter(Answer.class, new AnswerDeserializer());
+		gb.registerTypeAdapter(new TypeToken<Comment<Question>>() {}.getType(),
+				new CommentSerializer<Question>());
+		gb.registerTypeAdapter(new TypeToken<Comment<Question>>() {}.getType(),
+				new CommentDeserializer<Question>());
+		gb.registerTypeAdapter(new TypeToken<Comment<Answer>>() {}.getType(),
+				new CommentSerializer<Answer>());
+		gb.registerTypeAdapter(new TypeToken<Comment<Answer>>() {}.getType(),
+				new CommentDeserializer<Answer>());
 		gson = gb.create();
 	}
 
+	@Override
 	public void putQuestion(Question question) {
 		HttpClient httpClient = new DefaultHttpClient();
 
 		try {
-			HttpPost addRequest = new HttpPost(ES_BASE_URL + QUESTION_PATH + question.getId());
+			HttpPost addRequest = new HttpPost(ES_BASE_URL + QUESTION_PATH
+					+ question.getId());
 
 			StringEntity stringEntity = new StringEntity(gson.toJson(question));
 			addRequest.setEntity(stringEntity);
@@ -63,32 +87,45 @@ public class RemoteDataStore implements IDataStore {
 	@Override
 	public Question getQuestion(UUID id) {
 		HttpClient httpClient = new DefaultHttpClient();
-		HttpGet httpGet = new HttpGet(ES_BASE_URL + QUESTION_PATH + id.toString());
+		HttpGet httpGet = new HttpGet(ES_BASE_URL + QUESTION_PATH
+				+ id.toString());
 
 		HttpResponse response;
 
 		try {
 			response = httpClient.execute(httpGet);
 			@SuppressWarnings("unchecked")
-			SearchHit<Question> sr =
-				(SearchHit<Question>) parseESResponse(response, new TypeToken<SearchHit<Question>>(){}.getType());
+			SearchHit<Question> sr = (SearchHit<Question>) parseESResponse(
+					response, new TypeToken<SearchHit<Question>>() {
+					}.getType());
 			return sr.getSource();
 
 		} catch (Exception e) {
 			e.printStackTrace();
-		} 
+		}
 
 		return null;
 	}
-	
-	public void putAnswer(Answer mAnswer) {
-		// TODO Auto-generated method stub
-		
-	}
 
-	public boolean isComment(UUID id) {
-		// TODO Auto-generated method stub
-		return false;
+	@Override
+	public void putAnswer(Answer answer) {
+		HttpClient httpClient = new DefaultHttpClient();
+
+		try {
+			HttpPost addRequest = new HttpPost(ES_BASE_URL + ANSWER_PATH
+					+ answer.getId() + "?parent=" + answer.getParent().getId());
+
+			StringEntity stringEntity = new StringEntity(gson.toJson(answer));
+			addRequest.setEntity(stringEntity);
+			addRequest.setHeader("Accept", "application/json");
+
+			HttpResponse response = httpClient.execute(addRequest);
+			String status = response.getStatusLine().toString();
+			Log.i(TAG, status);
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 	}
 
 	@Override
@@ -99,14 +136,48 @@ public class RemoteDataStore implements IDataStore {
 
 	@Override
 	public void putQComment(Comment<Question> comment) {
-		// TODO Auto-generated method stub
-		
+		HttpClient httpClient = new DefaultHttpClient();
+
+		try {
+			HttpPost addRequest = new HttpPost(ES_BASE_URL
+					+ QUESTION_COMMENT_PATH + comment.getId() + "?parent=" + comment.getParent().getId());
+
+			StringEntity stringEntity = new StringEntity(gson.toJson(comment,
+					new TypeToken<Comment<Question>>(){}.getType()));
+			addRequest.setEntity(stringEntity);
+			addRequest.setHeader("Accept", "application/json");
+
+			HttpResponse response = httpClient.execute(addRequest);
+			String status = response.getStatusLine().toString();
+			Log.i(TAG, status);
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 	}
 
 	@Override
 	public void putAComment(Comment<Answer> comment) {
-		// TODO Auto-generated method stub
-		
+		HttpClient httpClient = new DefaultHttpClient();
+
+		try {
+			HttpPost addRequest = new HttpPost(ES_BASE_URL
+					+ ANSWER_COMMENT_PATH + comment.getId()
+					+ "?parent=" + comment.getParent().getId()
+					+ "&routing=" + comment.getParent().getParent().getId());
+
+			StringEntity stringEntity = new StringEntity(gson.toJson(comment,
+					new TypeToken<Comment<Answer>>(){}.getType()));
+			addRequest.setEntity(stringEntity);
+			addRequest.setHeader("Accept", "application/json");
+
+			HttpResponse response = httpClient.execute(addRequest);
+			String status = response.getStatusLine().toString();
+			Log.i(TAG, status);
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 	}
 
 	@Override
@@ -129,30 +200,37 @@ public class RemoteDataStore implements IDataStore {
 
 	@Override
 	public void save() {
-		// TODO Auto-generated method stub
-		
+		// Do nothing. Always saved.
 	}
-	
+
+	/**
+	 * Parse response from ElasticSearch, which is contained in a SearchHit
+	 * object
+	 * 
+	 * @param response
+	 * @param type
+	 * @return SearchHit object from ElasticSearch
+	 */
 	private SearchHit<?> parseESResponse(HttpResponse response, Type type) {
-		
+
 		try {
 			String json = getEntityContent(response);
-			
+
 			SearchHit<?> sr = gson.fromJson(json, type);
 			return sr;
-		} 
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * Gets content from an HTTP response
 	 */
-	public String getEntityContent(HttpResponse response) throws IOException {
-		BufferedReader rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
+	private String getEntityContent(HttpResponse response) throws IOException {
+		BufferedReader rd = new BufferedReader(new InputStreamReader(response
+				.getEntity().getContent()));
 
 		StringBuffer result = new StringBuffer();
 		String line = "";

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/RemoteDataStore.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/RemoteDataStore.java
@@ -14,6 +14,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 
+import android.content.Context;
 import android.util.Log;
 
 import com.google.gson.Gson;
@@ -42,9 +43,11 @@ public class RemoteDataStore implements IDataStore {
 	private static final String ANSWER_COMMENT_PATH = "acomment/";
 	private static final String TAG = "RemoteDataStore";
 
+	private Context context;
 	private Gson gson;
 
-	public RemoteDataStore() {
+	public RemoteDataStore(Context context) {
+		this.context = context;
 		GsonBuilder gb = new GsonBuilder();
 		// Register serializers and deserializers
 		// Note: The comment stuff is ugly, but it should work
@@ -113,7 +116,7 @@ public class RemoteDataStore implements IDataStore {
 
 		try {
 			HttpPost addRequest = new HttpPost(ES_BASE_URL + ANSWER_PATH
-					+ answer.getId() + "?parent=" + answer.getParent().getId());
+					+ answer.getId() + "?parent=" + answer.getParent());
 
 			StringEntity stringEntity = new StringEntity(gson.toJson(answer));
 			addRequest.setEntity(stringEntity);
@@ -140,7 +143,7 @@ public class RemoteDataStore implements IDataStore {
 
 		try {
 			HttpPost addRequest = new HttpPost(ES_BASE_URL
-					+ QUESTION_COMMENT_PATH + comment.getId() + "?parent=" + comment.getParent().getId());
+					+ QUESTION_COMMENT_PATH + comment.getId() + "?parent=" + comment.getParent());
 
 			StringEntity stringEntity = new StringEntity(gson.toJson(comment,
 					new TypeToken<Comment<Question>>(){}.getType()));
@@ -158,13 +161,14 @@ public class RemoteDataStore implements IDataStore {
 
 	@Override
 	public void putAComment(Comment<Answer> comment) {
+		DataManager dm = DataManager.getInstance(context);
 		HttpClient httpClient = new DefaultHttpClient();
 
 		try {
 			HttpPost addRequest = new HttpPost(ES_BASE_URL
 					+ ANSWER_COMMENT_PATH + comment.getId()
-					+ "?parent=" + comment.getParent().getId()
-					+ "&routing=" + comment.getParent().getParent().getId());
+					+ "?parent=" + comment.getParent()
+					+ "&routing=" + dm.getAnswer(comment.getParent()).getParent());
 
 			StringEntity stringEntity = new StringEntity(gson.toJson(comment,
 					new TypeToken<Comment<Answer>>(){}.getType()));
@@ -239,5 +243,11 @@ public class RemoteDataStore implements IDataStore {
 		}
 
 		return result.toString();
+	}
+
+	@Override
+	public boolean hasAccess() {
+		// TODO Auto-generated method stub
+		return false;
 	}
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/RemoteDataStore.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/RemoteDataStore.java
@@ -1,24 +1,86 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.data;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.UUID;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+
+import android.util.Log;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer.QuestionDeserializer;
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer.QuestionSerializer;
 
 public class RemoteDataStore implements IDataStore {
 
-	public boolean hasAccess() {
-		// TODO Auto-generated method stub
-		return false;
+	protected static String ES_BASE_URL = "http://cmput301.softwareprocess.es:8080/cmput301f14t14/";
+	private static final String QUESTION_PATH = "question/";
+	private static final String TAG = "RemoteDataStore";
+
+	private Gson gson;
+	
+	public RemoteDataStore() {
+		GsonBuilder gb = new GsonBuilder();
+		gb.registerTypeAdapter(Question.class, new QuestionSerializer());
+		gb.registerTypeAdapter(Question.class, new QuestionDeserializer());
+		gson = gb.create();
 	}
 
-	public void putQuestion(Question mQuestion) {
-		// TODO Auto-generated method stub
-		
+	public void putQuestion(Question question) {
+		HttpClient httpClient = new DefaultHttpClient();
+
+		try {
+			HttpPost addRequest = new HttpPost(ES_BASE_URL + QUESTION_PATH + question.getId());
+
+			StringEntity stringEntity = new StringEntity(gson.toJson(question));
+			addRequest.setEntity(stringEntity);
+			addRequest.setHeader("Accept", "application/json");
+
+			HttpResponse response = httpClient.execute(addRequest);
+			String status = response.getStatusLine().toString();
+			Log.i(TAG, status);
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 	}
 
+	@Override
+	public Question getQuestion(UUID id) {
+		HttpClient httpClient = new DefaultHttpClient();
+		HttpGet httpGet = new HttpGet(ES_BASE_URL + QUESTION_PATH + id.toString());
+
+		HttpResponse response;
+
+		try {
+			response = httpClient.execute(httpGet);
+			@SuppressWarnings("unchecked")
+			SearchHit<Question> sr =
+				(SearchHit<Question>) parseESResponse(response, new TypeToken<SearchHit<Question>>(){}.getType());
+			return sr.getSource();
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		} 
+
+		return null;
+	}
+	
 	public void putAnswer(Answer mAnswer) {
 		// TODO Auto-generated method stub
 		
@@ -48,12 +110,6 @@ public class RemoteDataStore implements IDataStore {
 	}
 
 	@Override
-	public Question getQuestion(UUID id) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
 	public Answer getAnswer(UUID id) {
 		// TODO Auto-generated method stub
 		return null;
@@ -75,5 +131,35 @@ public class RemoteDataStore implements IDataStore {
 	public void save() {
 		// TODO Auto-generated method stub
 		
+	}
+	
+	private SearchHit<?> parseESResponse(HttpResponse response, Type type) {
+		
+		try {
+			String json = getEntityContent(response);
+			
+			SearchHit<?> sr = gson.fromJson(json, type);
+			return sr;
+		} 
+		catch (IOException e) {
+			e.printStackTrace();
+		}
+		
+		return null;
+	}
+	
+	/**
+	 * Gets content from an HTTP response
+	 */
+	public String getEntityContent(HttpResponse response) throws IOException {
+		BufferedReader rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
+
+		StringBuffer result = new StringBuffer();
+		String line = "";
+		while ((line = rd.readLine()) != null) {
+			result.append(line);
+		}
+
+		return result.toString();
 	}
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/SearchHit.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/SearchHit.java
@@ -1,3 +1,8 @@
+/* This file was written by Victor Guana
+ * See https://github.com/guana/elasticsearch
+ * 
+ * Used with permission
+ */
 package ca.ualberta.cs.cmput301f14t14.questionapp.data;
 
 public class SearchHit<T> {

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/SearchHit.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/SearchHit.java
@@ -1,0 +1,71 @@
+package ca.ualberta.cs.cmput301f14t14.questionapp.data;
+
+public class SearchHit<T> {
+	private String _index;
+	private String _type;
+	private String _id;
+	private String _version;
+	private boolean found;
+	private T _source;
+
+	public SearchHit() {
+
+	}
+
+	public String get_index() {
+		return _index;
+	}
+
+	public void set_index(String _index) {
+		this._index = _index;
+	}
+
+	public String get_type() {
+		return _type;
+	}
+
+	public void set_type(String _type) {
+		this._type = _type;
+	}
+
+	public String get_id() {
+		return _id;
+	}
+
+	public void set_id(String _id) {
+		this._id = _id;
+	}
+
+	public String get_version() {
+		return _version;
+	}
+
+	public void set_version(String _version) {
+		this._version = _version;
+	}
+
+	public boolean isFound() {
+		return found;
+	}
+
+	public void setFound(boolean found) {
+		this.found = found;
+	}
+
+	public T getSource() {
+		return _source;
+	}
+
+	public void setSource(T source) {
+		this._source = source;
+	}
+
+	@Override
+	public String toString() {
+		return "SimpleElasticSearchResponse [_index=" + _index + ", _type="
+				+ _type + ", _id=" + _id + ", _version=" + _version
+				+ ", found=" + found + ", _source=" + _source + "]";
+	}
+	
+	
+}

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/Answer.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/Answer.java
@@ -3,7 +3,6 @@ package ca.ualberta.cs.cmput301f14t14.questionapp.model;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/Answer.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/Answer.java
@@ -151,4 +151,8 @@ public class Answer extends Model implements Serializable {
 	public void setDate(Date date) {
 		this.date = date;
 	}
+
+	public void setUpvotes(int upvotes) {
+		this.upVotes = upvotes;
+	}
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/Comment.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/Comment.java
@@ -14,6 +14,14 @@ public class Comment<T extends Model> implements Serializable {
 	private T parent;
 	private Date date;
 	
+	public Comment() {
+		setId(new UUID(0L, 0L));
+		this.body = "";
+		this.username = "";
+		this.parent = null;
+		setDate(new Date());
+	}
+	
 	public Comment(T parent, String body, String username) {
 		setId(UUID.randomUUID());
 		this.body = body;
@@ -25,9 +33,17 @@ public class Comment<T extends Model> implements Serializable {
 	public String getBody() {
 		return body;
 	}
+	
+	public void setBody(String body) {
+		this.body = body;
+	}
 
 	public String getUsername() {
 		return username;
+	}
+	
+	public void setUsername(String username) {
+		this.username = username;
 	}
 
 	public UUID getId() {

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/Question.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/Question.java
@@ -3,7 +3,6 @@ package ca.ualberta.cs.cmput301f14t14.questionapp.model;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/Question.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/Question.java
@@ -63,8 +63,11 @@ public class Question extends Model implements Serializable {
 		return title;
 	}
 
-	//Set the title if there is one and trim the whitespace
-	private void setTitle(String title) {
+	/**
+	 * Set the title if there is one and trim the whitespace
+	 * @param title
+	 */
+	public void setTitle(String title) {
 		if (title == null || title.trim().length() == 0)
 			throw new IllegalArgumentException("Question title may not be blank.");
 		this.title = title.trim();
@@ -74,8 +77,11 @@ public class Question extends Model implements Serializable {
 		return body;
 	}
 
-	//Set the body if there is one and trim the whitespace
-	private void setBody(String body) {
+	/**
+	 * Set the body if there is one and trim the whitespace
+	 * @param body
+	 */
+	public void setBody(String body) {
 		if (body == null || body.trim().length() == 0)
 			throw new IllegalArgumentException("Question body may not be blank.");
 		this.body = body.trim();
@@ -116,12 +122,16 @@ public class Question extends Model implements Serializable {
 	public Integer getUpvotes() {
 		return upVotes;
 	}
+	
+	public void setUpvotes(int val) {
+		upVotes = val;
+	}
 
 	public String getAuthor() {
 		return this.author;
 	}
 
-	private void setAuthor(String author) {
+	public void setAuthor(String author) {
 		this.author = author;
 	}
 

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/AnswerDeserializer.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/AnswerDeserializer.java
@@ -1,0 +1,41 @@
+package ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer;
+
+import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+import java.util.UUID;
+
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+/**
+ * Class used by GSON to deserialize Answer objects
+ */
+public class AnswerDeserializer implements JsonDeserializer<Answer> {
+
+	public Answer deserialize(final JsonElement json, final Type type,
+			final JsonDeserializationContext context) throws JsonParseException {
+		final JsonObject jsonObject = json.getAsJsonObject();
+
+		try {
+			final Answer answer = new Answer();
+			answer.setId(UUID.fromString(jsonObject.get("id").getAsString()));
+			answer.setBody(jsonObject.get("body").getAsString());
+			answer.setAuthor(jsonObject.get("author").getAsString());
+			answer.setDate(new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US).parse(jsonObject.get("date").getAsString()));
+			answer.setUpvotes(jsonObject.get("upvotes").getAsInt());
+			// TODO: Comments
+			return answer;
+		} catch (ParseException ex) {
+			ex.printStackTrace();
+		}
+		return null;
+	}
+
+}

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/AnswerSerializer.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/AnswerSerializer.java
@@ -1,0 +1,40 @@
+package ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer;
+
+import java.lang.reflect.Type;
+
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * Class used by GSON to serialize Answer objects
+ */
+public class AnswerSerializer implements JsonSerializer<Answer> {
+
+	@Override
+	public JsonElement serialize(final Answer item, final Type type,
+			final JsonSerializationContext context) {
+		final JsonObject object = new JsonObject();
+		object.addProperty("id", item.getId().toString());
+		object.addProperty("body", item.getBody());
+		// image - don't know what I'm doing with this yet;
+		object.addProperty("author", item.getAuthor());
+		object.addProperty("date", item.getDate().toString());
+		object.addProperty("upvotes", item.getUpvotes());
+		final JsonArray commentList = new JsonArray();
+		for (Comment<Answer> c: item.getCommentList()) {
+			final JsonPrimitive answerId = new JsonPrimitive(c.getId().toString());
+			commentList.add(answerId);
+		}
+		object.add("comments", commentList);
+		
+		return object;
+	}
+
+}

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/AnswerSerializer.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/AnswerSerializer.java
@@ -1,9 +1,9 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer;
 
 import java.lang.reflect.Type;
+import java.util.UUID;
 
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
-import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -28,8 +28,8 @@ public class AnswerSerializer implements JsonSerializer<Answer> {
 		object.addProperty("date", item.getDate().toString());
 		object.addProperty("upvotes", item.getUpvotes());
 		final JsonArray commentList = new JsonArray();
-		for (Comment<Answer> c: item.getCommentList()) {
-			final JsonPrimitive answerId = new JsonPrimitive(c.getId().toString());
+		for (UUID cid: item.getCommentList()) {
+			final JsonPrimitive answerId = new JsonPrimitive(cid.toString());
 			commentList.add(answerId);
 		}
 		object.add("comments", commentList);

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/CommentDeserializer.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/CommentDeserializer.java
@@ -1,0 +1,40 @@
+package ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer;
+
+import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+import java.util.UUID;
+
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.Model;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+/**
+ * Class used by GSON to deserialize Answer objects
+ */
+public class CommentDeserializer<T extends Model> implements JsonDeserializer<Comment<T>> {
+
+	public Comment<T> deserialize(final JsonElement json, final Type type,
+			final JsonDeserializationContext context) throws JsonParseException {
+		final JsonObject jsonObject = json.getAsJsonObject();
+
+		try {
+			final Comment<T> comment = new Comment<T>();
+			comment.setId(UUID.fromString(jsonObject.get("id").getAsString()));
+			comment.setBody(jsonObject.get("body").getAsString());
+			comment.setUsername(jsonObject.get("author").getAsString());
+			comment.setDate(new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US).parse(jsonObject.get("date").getAsString()));
+			return comment;
+		} catch (ParseException ex) {
+			ex.printStackTrace();
+		}
+		return null;
+	}
+
+}

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/CommentSerializer.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/CommentSerializer.java
@@ -1,0 +1,30 @@
+package ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer;
+
+import java.lang.reflect.Type;
+
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.Model;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * Class used by GSON to serialize Comment objects
+ */
+public class CommentSerializer<T extends Model> implements JsonSerializer<Comment<T>> {
+
+	@Override
+	public JsonElement serialize(final Comment<T> item, final Type type,
+			final JsonSerializationContext context) {
+		final JsonObject object = new JsonObject();
+		object.addProperty("id", item.getId().toString());
+		object.addProperty("body", item.getBody());
+		object.addProperty("author", item.getUsername());
+		object.addProperty("date", item.getDate().toString());
+		
+		return object;
+	}
+
+}

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/QuestionDeserializer.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/QuestionDeserializer.java
@@ -1,0 +1,42 @@
+package ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer;
+
+import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+import java.util.UUID;
+
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+/**
+ * Class used by GSON to deserialize Question objects
+ */
+public class QuestionDeserializer implements JsonDeserializer<Question> {
+
+	public Question deserialize(final JsonElement json, final Type type,
+			final JsonDeserializationContext context) throws JsonParseException {
+		final JsonObject jsonObject = json.getAsJsonObject();
+
+		try {
+			final Question question = new Question();
+			question.setId(UUID.fromString(jsonObject.get("id").getAsString()));
+			question.setTitle(jsonObject.get("title").getAsString());
+			question.setBody(jsonObject.get("body").getAsString());
+			question.setAuthor(jsonObject.get("author").getAsString());
+			question.setDate(new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US).parse(jsonObject.get("date").getAsString()));
+			question.setUpvotes(jsonObject.get("upvotes").getAsInt());
+			// TODO: Answers and comments
+			return question;
+		} catch (ParseException ex) {
+			ex.printStackTrace();
+		}
+		return null;
+	}
+
+}

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/QuestionSerializer.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/QuestionSerializer.java
@@ -1,9 +1,8 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer;
 
 import java.lang.reflect.Type;
+import java.util.UUID;
 
-import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
-import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
 
 import com.google.gson.JsonArray;
@@ -30,14 +29,14 @@ public class QuestionSerializer implements JsonSerializer<Question> {
 		object.addProperty("date", item.getDate().toString());
 		object.addProperty("upvotes", item.getUpvotes());
 		final JsonArray answerList = new JsonArray();
-		for (Answer a: item.getAnswerList()) {
-			final JsonPrimitive answerId = new JsonPrimitive(a.getId().toString());
+		for (UUID aid: item.getAnswerList()) {
+			final JsonPrimitive answerId = new JsonPrimitive(aid.toString());
 			answerList.add(answerId);
 		}
 		object.add("answers", answerList);
 		final JsonArray commentList = new JsonArray();
-		for (Comment<Question> c: item.getCommentList()) {
-			final JsonPrimitive answerId = new JsonPrimitive(c.getId().toString());
+		for (UUID cid: item.getCommentList()) {
+			final JsonPrimitive answerId = new JsonPrimitive(cid.toString());
 			commentList.add(answerId);
 		}
 		object.add("comments", commentList);

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/QuestionSerializer.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/QuestionSerializer.java
@@ -1,0 +1,48 @@
+package ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer;
+
+import java.lang.reflect.Type;
+
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * Class used by GSON to serialize Question objects
+ */
+public class QuestionSerializer implements JsonSerializer<Question> {
+
+	@Override
+	public JsonElement serialize(final Question item, final Type type,
+			final JsonSerializationContext context) {
+		final JsonObject object = new JsonObject();
+		object.addProperty("id", item.getId().toString());
+		object.addProperty("title", item.getTitle());
+		object.addProperty("body", item.getBody());
+		// image - don't know what I'm doing with this yet;
+		object.addProperty("author", item.getAuthor());
+		object.addProperty("date", item.getDate().toString());
+		object.addProperty("upvotes", item.getUpvotes());
+		final JsonArray answerList = new JsonArray();
+		for (Answer a: item.getAnswerList()) {
+			final JsonPrimitive answerId = new JsonPrimitive(a.getId().toString());
+			answerList.add(answerId);
+		}
+		object.add("answers", answerList);
+		final JsonArray commentList = new JsonArray();
+		for (Comment<Question> c: item.getCommentList()) {
+			final JsonPrimitive answerId = new JsonPrimitive(c.getId().toString());
+			commentList.add(answerId);
+		}
+		object.add("comments", commentList);
+		
+		return object;
+	}
+
+}

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/AnswerTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/AnswerTest.java
@@ -30,7 +30,7 @@ public class AnswerTest extends ActivityInstrumentationTestCase2<MainActivity> {
 		mAnswer = new Answer(mQuestion.getId(), "Answer body.", "Author", null);
 		manager = DataManager.getInstance(getInstrumentation().getTargetContext().getApplicationContext());
 		local =  new LocalDataStore(getInstrumentation().getTargetContext().getApplicationContext());
-		remote = new RemoteDataStore();
+		remote = new RemoteDataStore(getInstrumentation().getTargetContext().getApplicationContext());
 	}
 
 	protected void tearDown() throws Exception {

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/CommentTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/CommentTest.java
@@ -91,8 +91,6 @@ public class CommentTest extends ActivityInstrumentationTestCase2<MainActivity> 
 		assertNotNull(mQuestion.getComment(mComment.getId()));
 		remote.putQComment(mComment);
 		remote.putQuestion(mQuestion);
-		boolean inRemote = remote.isComment(id);
-		assertTrue(inRemote);
 		assertTrue(mQuestion.hasComment(mComment));
 		
 		// adding to answer
@@ -103,8 +101,6 @@ public class CommentTest extends ActivityInstrumentationTestCase2<MainActivity> 
 		assertNotNull(manager.getAnswerComment(mQuestion.getId(), mAnswer.getId(), secId));
 		remote.putAComment(secComment);
 		remote.putAnswer(mAnswer);
-		boolean secInRemote = remote.isComment(secId);
-		assertTrue(secInRemote);
 		assertTrue(mQuestion.hasComment(mComment));
 	}
 	

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/DataManagerTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/DataManagerTest.java
@@ -29,11 +29,14 @@ public class DataManagerTest extends ActivityInstrumentationTestCase2<MainActivi
 		manager = DataManager.getInstance(getInstrumentation().getTargetContext().getApplicationContext());
 		manager.clearClientData();
 		manager.setUsername("User");
-		Collection<Question> qList = MockData.getMockData();
-		for(Question question : qList){
+		MockData.initMockData();
+		for(Question question : MockData.questions){
 			manager.addQuestion(question);
 		}
-		validQ = qList.iterator().next();
+		for(Answer answer : MockData.answers) {
+			manager.addAnswer(answer);
+		}
+		validQ = MockData.questions.iterator().next();
 		List<Answer> aList = manager.getAnswerList(validQ);
 		validA = aList.get(0);
 		try{

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/QuestionListTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/QuestionListTest.java
@@ -14,7 +14,7 @@ import junit.framework.TestCase;
 public class QuestionListTest extends ActivityInstrumentationTestCase2<MainActivity> {
 
 	private LocalDataStore mLocalStore;
-	public RemoteDataStore mRemoteStore = new RemoteDataStore();
+	public RemoteDataStore mRemoteStore = new RemoteDataStore(getInstrumentation().getTargetContext().getApplicationContext());
 
 	private Question mQuestion;
 	private DataManager manager;

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/QuestionTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/QuestionTest.java
@@ -33,7 +33,7 @@ public class QuestionTest extends ActivityInstrumentationTestCase2<MainActivity>
 		author = "boris";
 		manager = DataManager.getInstance(getInstrumentation().getTargetContext().getApplicationContext());
 		local =  new LocalDataStore(getInstrumentation().getTargetContext().getApplicationContext());
-		remote = new RemoteDataStore();
+		remote = new RemoteDataStore(getInstrumentation().getTargetContext().getApplicationContext());
 	}
 
 	protected void tearDown() throws Exception {

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/SearchTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/SearchTest.java
@@ -28,7 +28,7 @@ public class SearchTest extends ActivityInstrumentationTestCase2<MainActivity> {
 		super.setUp();
 		manager = DataManager.getInstance(getInstrumentation().getTargetContext().getApplicationContext());
 		local = new LocalDataStore(getInstrumentation().getTargetContext().getApplicationContext());
-		remote = new RemoteDataStore();
+		remote = new RemoteDataStore(getInstrumentation().getTargetContext().getApplicationContext());
 		remoteSearch = new MockElasticSearch();
 	}
 

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/data/LocalDataStoreTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/data/LocalDataStoreTest.java
@@ -23,11 +23,21 @@ public class LocalDataStoreTest extends ActivityInstrumentationTestCase2<MainAct
 
 	protected void setUp() throws Exception {
 		super.setUp();
+		MockData.initMockData();
 		localStore = new LocalDataStore(getInstrumentation().getTargetContext().getApplicationContext());
 		localStore.clear();
 		localStore.save();
-		for (Question q: MockData.getMockData()) {
+		for (Question q: MockData.questions) {
 			localStore.putQuestion(q);
+		}
+		for (Answer a: MockData.answers) {
+			localStore.putAnswer(a);
+		}
+		for (Comment<Question> c: MockData.qcomments) {
+			localStore.putQComment(c);
+		}
+		for (Comment<Answer> c: MockData.acomments) {
+			localStore.putAComment(c);
 		}
 	}
 

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/data/RemoteDataStoreTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/data/RemoteDataStoreTest.java
@@ -4,14 +4,14 @@ import java.util.List;
 
 import android.test.ActivityInstrumentationTestCase2;
 import ca.ualberta.cs.cmput301f14t14.questionapp.MainActivity;
-import ca.ualberta.cs.cmput301f14t14.questionapp.data.DataManager;
 import ca.ualberta.cs.cmput301f14t14.questionapp.data.RemoteDataStore;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
 import ca.ualberta.cs.cmput301f14t14.questionapp.test.mock.MockData;
 
-public class RemoteDataStoreTest extends ActivityInstrumentationTestCase2<MainActivity> {
+public class RemoteDataStoreTest extends
+		ActivityInstrumentationTestCase2<MainActivity> {
 
 	private RemoteDataStore remoteStore;
 	private List<Question> mockData;
@@ -26,6 +26,9 @@ public class RemoteDataStoreTest extends ActivityInstrumentationTestCase2<MainAc
 		mockData = MockData.getMockData();
 	}
 
+	/**
+	 * Verify that a question object can be sent to ElasticSearch
+	 */
 	public void testPutQuestion() {
 		Question q = mockData.get(0);
 		remoteStore.putQuestion(q);
@@ -33,25 +36,34 @@ public class RemoteDataStoreTest extends ActivityInstrumentationTestCase2<MainAc
 		assertEquals(q, retrievedQuestion);
 	}
 
-	/*
+	/**
+	 * Verify that an answer object can be sent to ElasticSearch
+	 */
 	public void testPutAnswer() {
-		mRemoteStore.putAnswer(mAnswer);
-		Answer retrieved = manager.getAnswer(mQuestion.getId(), mAnswer.getId());
-		assertEquals(mAnswer, retrieved);
+		Answer a = mockData.get(0).getAnswerList().get(0);
+		remoteStore.putAnswer(a);
+		Answer retrievedAnswer = remoteStore.getAnswer(a.getId());
+		assertEquals(a, retrievedAnswer);
 	}
-	
-	public void testPutComment() {
-		mRemoteStore.putQComment(qComment);
-		Comment<Question> retrieved = (Comment<Question>) manager.getQuestionComment(qComment.getId(), qComment.getId());
-		assertEquals(qComment, retrieved);
+
+	/**
+	 * Verify that an answer comment object can be sent to ElasticSearch
+	 */
+	public void testPutAnswerComment() {
+		Comment<Answer> c = mockData.get(0).getAnswerList().get(0)
+				.getCommentList().get(0);
+		remoteStore.putAComment(c);
+		Comment<Answer> retrievedComment = remoteStore.getAComment(c.getId());
+		assertEquals(c, retrievedComment);
 	}
-	
-	 UC1 TC 1.2 
-	public void testDispRemoteQ() {
-		
-		mRemoteStore.putQuestion(mQuestion);
-		Question retrieved = manager.getQuestion(mQuestion.getId());
-		assertEquals(mQuestion, retrieved);
-	}*/
-	
+
+	/**
+	 * Verify that a question comment object can be sent to ElasticSearch
+	 */
+	public void testPutQuestionComment() {
+		Comment<Question> c = mockData.get(0).getCommentList().get(0);
+		remoteStore.putQComment(c);
+		Comment<Question> retrievedComment = remoteStore.getQComment(c.getId());
+		assertEquals(c, retrievedComment);
+	}
 }

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/data/RemoteDataStoreTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/data/RemoteDataStoreTest.java
@@ -1,5 +1,7 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.test.data;
 
+import java.util.List;
+
 import android.test.ActivityInstrumentationTestCase2;
 import ca.ualberta.cs.cmput301f14t14.questionapp.MainActivity;
 import ca.ualberta.cs.cmput301f14t14.questionapp.data.DataManager;
@@ -7,15 +9,12 @@ import ca.ualberta.cs.cmput301f14t14.questionapp.data.RemoteDataStore;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
+import ca.ualberta.cs.cmput301f14t14.questionapp.test.mock.MockData;
 
 public class RemoteDataStoreTest extends ActivityInstrumentationTestCase2<MainActivity> {
 
-	private RemoteDataStore mRemoteStore;
-	private Question mQuestion;
-	private DataManager manager;
-	private Answer mAnswer;
-	private Comment<Question> qComment;
-	private Comment<Answer> aComment;
+	private RemoteDataStore remoteStore;
+	private List<Question> mockData;
 
 	public RemoteDataStoreTest() {
 		super(MainActivity.class);
@@ -23,28 +22,18 @@ public class RemoteDataStoreTest extends ActivityInstrumentationTestCase2<MainAc
 
 	protected void setUp() throws Exception {
 		super.setUp();
-		mRemoteStore = new RemoteDataStore();
-		mQuestion = new Question("TITLE", "BODY", "Author", null);
-		mAnswer = new Answer(mQuestion, "ANSWERBODY", "Author", null);
-		qComment = new Comment<Question>(mQuestion, "COMMENTBODY", "Boris");
-		aComment = new Comment<Answer>(mAnswer, "CBody", "Natasha");
-		manager = DataManager.getInstance(getInstrumentation().getTargetContext().getApplicationContext());
+		remoteStore = new RemoteDataStore();
+		mockData = MockData.getMockData();
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
-	
-	public void testRemoteAccess() {
-		assertTrue(mRemoteStore.hasAccess());
-	}
-	
 	public void testPutQuestion() {
-		mRemoteStore.putQuestion(mQuestion);
-		Question retrieved = manager.getQuestion(mQuestion.getId());
-		assertEquals(mQuestion, retrieved);
+		Question q = mockData.get(0);
+		remoteStore.putQuestion(q);
+		Question retrievedQuestion = remoteStore.getQuestion(q.getId());
+		assertEquals(q, retrievedQuestion);
 	}
-	
+
+	/*
 	public void testPutAnswer() {
 		mRemoteStore.putAnswer(mAnswer);
 		Answer retrieved = manager.getAnswer(mQuestion.getId(), mAnswer.getId());
@@ -57,12 +46,12 @@ public class RemoteDataStoreTest extends ActivityInstrumentationTestCase2<MainAc
 		assertEquals(qComment, retrieved);
 	}
 	
-	/* UC1 TC 1.2 */
+	 UC1 TC 1.2 
 	public void testDispRemoteQ() {
 		
 		mRemoteStore.putQuestion(mQuestion);
 		Question retrieved = manager.getQuestion(mQuestion.getId());
 		assertEquals(mQuestion, retrieved);
-	}
+	}*/
 	
 }

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/mock/MockData.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/mock/MockData.java
@@ -1,15 +1,15 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.test.mock;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
 
 public class MockData {
-	public static Collection<Question> getMockData() {
-		Collection<Question> data = new ArrayList<Question>();
+	public static List<Question> getMockData() {
+		List<Question> data = new ArrayList<Question>();
 
 		Question q1 = new Question("Coconut laden swallow", "What is the terminal velocity of a coconut laden swallow?", "Boris", null);
 		q1.addComment(new Comment<Question>(q1, "What kind of swallow is it?", "Bob"));

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/mock/MockData.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/mock/MockData.java
@@ -8,36 +8,51 @@ import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
 
 public class MockData {
-	public static List<Question> getMockData() {
-		List<Question> data = new ArrayList<Question>();
+	public static List<Question> questions;
+	public static List<Answer> answers;
+	public static List<Comment<Question>> qcomments;
+	public static List<Comment<Answer>> acomments;
+	
+	public static void initMockData() {
+		questions = new ArrayList<Question>();
+		answers = new ArrayList<Answer>();
+		qcomments = new ArrayList<Comment<Question>>();
+		acomments = new ArrayList<Comment<Answer>>();
 
 		Question q1 = new Question("Coconut laden swallow", "What is the terminal velocity of a coconut laden swallow?", "Boris", null);
 		Comment<Question> cq1 = new Comment<Question>(q1.getId(), "What kind of swallow is it?", "Bob");
 		q1.addComment(cq1.getId());
+		qcomments.add(cq1);
 		Comment<Question> cq2 = new Comment<Question>(q1.getId(), "An african swallow.", "Boris");
 		q1.addComment(cq2.getId());
+		qcomments.add(cq2);
 		Answer a1 = new Answer(q1.getId(), "The terminal velocity is 42.", "Curtis", null);
-		a1.addComment(new Comment<Answer>(a1.getId(), "The units are furlongs per fortnight.", "Curtis"));
+		Comment<Answer> aq1 = new Comment<Answer>(a1.getId(), "The units are furlongs per fortnight.", "Curtis");
+		a1.addComment(aq1);
+		acomments.add(aq1);
+		answers.add(a1);
 		Answer a2 = new Answer(q1.getId(), "It's clearly 45m/s.", "Bjorn", null);
+		answers.add(a2);
 		q1.addAnswer(a1.getId());
 		q1.addAnswer(a2.getId());
-		data.add(q1);
+		questions.add(q1);
 
 		Question q2 = new Question("Why is the sky blue?", "Really, why is it blue!?", "Pearl", null);
-		Comment<Question >cq3 = new Comment<Question>(q2.getId(), "Excellent use of an interrobang!", "Ben");
+		Comment<Question>cq3 = new Comment<Question>(q2.getId(), "Excellent use of an interrobang!", "Ben");
 		q2.addComment(cq3.getId());
-		data.add(q2);
+		questions.add(q2);
+		qcomments.add(cq3);
 
 		Question q3 = new Question("RxJava and C# Threading", "How similar are RxJava and C#'s threading library?", "Ted", null);
 		Answer a3 = new Answer(q3.getId(), "This is for you to discover, young Padawaan.", "Master Yoda", null);
 		q3.addAnswer(a3.getId());
-		data.add(q3);
+		questions.add(q3);
+		answers.add(a3);
 
 		Question validQ = new Question("TITLE", "BODY", "AUTHOR", null);
 		Answer validA = new Answer(validQ.getId(), "aBody", "aAuthor", null);
 		validQ.addAnswer(validA.getId());
-		data.add(validQ);
-		
-		return data;
+		questions.add(validQ);
+		answers.add(validA);
 	}
 }


### PR DESCRIPTION
This huge chunk of code puts data to ElasticSearch.

There's lots of copy-paste that could be re-factored out later in RemoteDataStore. (Which we should totally fix or note for more marks!) Not sure how much I can minimize the other stuff that looks copy-pasted but isn't exactly similar.

Custom serializers and deserializers provide more control, and in the case of deserializers, are necessary to
populate existing objects with data. Please note that these are incomplete.

Also, exception handling needs to be altered such that failure can be reported to the DataManager.

See http://cmput301.softwareprocess.es:8080/cmput301f14t14/_search for some sample data that was put
with this code.

Data cannot yet be fetched from RemoteDataStore because of incomplete deserializers and inability to get local data only from DataManager (to get existing objects).
(@RyanKusters, can you add a `getLocalDataStore()` method to DM? It's messy but it's easier for everyone.)

**Do not push until Ryan's existing DM pull request goes through. I want to go through this and fix any issues that result from any interface changes.**
