### PR TITLE
Added threading to AddQuestion.

### DIFF
--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 import android.content.Context;
 
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.threading.AddQuestionTask;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
@@ -26,6 +27,7 @@ public class DataManager {
 	private List<UUID> readLater;
 	private List<UUID> pushOnline;
 	private List<UUID> upVoteOnline;
+	private Context singletoncontext; //Needed for Threading instantiations
 	String Username;
 
 	
@@ -35,6 +37,7 @@ public class DataManager {
 		this.remoteDataStore = new RemoteDataStore(context);
 		this.pushOnline = new ArrayList<UUID>();
 		this.upVoteOnline = new ArrayList<UUID>();
+		this.singletoncontext = context;
 	}
 
 	/**
@@ -52,8 +55,10 @@ public class DataManager {
 	//View Interface Begins
 	public void addQuestion(Question validQ) {
 		if(remoteDataStore.hasAccess()){
-			remoteDataStore.putQuestion(validQ);
-		  	remoteDataStore.save();
+			
+			AddQuestionTask aqt = new AddQuestionTask(this.singletoncontext);
+			aqt.execute(validQ);
+			
 		}
 		else{
 			pushOnline.add(validQ.getId());
@@ -320,6 +325,14 @@ public class DataManager {
 		localDataStore.save();
 		
 		
+	}
+
+	public IDataStore getLocalDataStore() {
+		return localDataStore;
+	}
+
+	public IDataStore getRemoteDataStore() {
+		return remoteDataStore;
 	}
 
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AbstractDataManagerTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AbstractDataManagerTask.java
@@ -1,0 +1,18 @@
+package ca.ualberta.cs.cmput301f14t14.questionapp.data.threading;
+
+import android.content.Context;
+import android.os.AsyncTask;
+
+public abstract class AbstractDataManagerTask<S,T,V> extends AsyncTask<S,T,V> {
+	
+	protected Context context;
+	
+	public AbstractDataManagerTask(Context c) {
+		context = c;
+	}
+	
+	protected Context getContext() {
+		return context;
+	}
+
+}

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddQuestionTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddQuestionTask.java
@@ -1,0 +1,25 @@
+package ca.ualberta.cs.cmput301f14t14.questionapp.data.threading;
+
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.DataManager;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.IDataStore;
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
+import android.content.Context;
+
+public class AddQuestionTask extends AbstractDataManagerTask<Question, Void, Void>{
+
+	public AddQuestionTask(Context c) {
+		super(c);
+	}
+
+	@Override
+	protected Void doInBackground(Question... qin) {
+		Question q = qin[0]; // Ignore other questions inputted
+		IDataStore remote = DataManager.getInstance(this.getContext())
+			.getRemoteDataStore();
+		remote.putQuestion(q);
+		remote.save();
+		
+		return null;
+	}
+
+}


### PR DESCRIPTION
Each AsyncTask inherits from AbstractDataManagerTask. Every place in the
DataManager where we do stuff with the remote datastore, we need to
create a task that does that. Then instantiate, pass context, and call
.execute() on it to run it in a different thread.

Pretty much everything in DataManager will map to one of these tasks.
The AddQuestionTask is an example to follow. Other tasks may require
UI-thread updating to notify views of changes. These go in the thread's
onPostExecute() method.

Notice the carreful use of getting q[0] in the variadic (by interface)
function.

This pull request is rather small because it's getting late in the evening. I have created it so that Scott can pull it and see what I've done. Please merge this into trunk. The next PR will be much bigger with more tasks written.
