### PR TITLE
Get remote data

### DIFF
--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
@@ -15,7 +15,7 @@ import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
  * DataManager is a singleton that talks to local and remote data sources
  */
 public class DataManager {
-
+	
 	private static DataManager instance;
 
 	private ClientData clientData;
@@ -27,17 +27,26 @@ public class DataManager {
 	private List<UUID> readLater;
 	private List<UUID> pushOnline;
 	private List<UUID> upVoteOnline;
-	private Context singletoncontext; //Needed for Threading instantiations
+	private Context context; //Needed for Threading instantiations
 	String Username;
 
 	
-	private DataManager(Context context){
+	private DataManager(Context context) {
+		this.pushOnline = new ArrayList<UUID>();
+		this.upVoteOnline = new ArrayList<UUID>();
+		this.context = context;
+	}
+
+	/**
+	 * Create data stores
+	 * 
+	 * This must be done after the constructor, because some data stores
+	 * refer back to DataManager, and cannot do so until it is constructed.
+	 */
+	private void initDataStores() {
 		this.clientData = new ClientData(context);
 		this.localDataStore = new LocalDataStore(context);
 		this.remoteDataStore = new RemoteDataStore(context);
-		this.pushOnline = new ArrayList<UUID>();
-		this.upVoteOnline = new ArrayList<UUID>();
-		this.singletoncontext = context;
 	}
 
 	/**
@@ -48,6 +57,7 @@ public class DataManager {
 	public static DataManager getInstance(Context context){
 		if (instance == null){
 			instance = new DataManager(context.getApplicationContext());
+			instance.initDataStores();
 		}
 		return instance;
 	}
@@ -56,7 +66,7 @@ public class DataManager {
 	public void addQuestion(Question validQ) {
 		if(remoteDataStore.hasAccess()){
 			
-			AddQuestionTask aqt = new AddQuestionTask(this.singletoncontext);
+			AddQuestionTask aqt = new AddQuestionTask(this.context);
 			aqt.execute(validQ);
 			
 		}

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/Hits.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/Hits.java
@@ -1,0 +1,47 @@
+/* This file was written by Victor Guana
+ * See https://github.com/guana/elasticsearch
+ * 
+ * Used with permission
+ */
+package ca.ualberta.cs.cmput301f14t14.questionapp.data;
+
+import java.util.List;
+
+
+public class Hits<T> {
+	private int total;
+	private float max_score;
+	private List<SearchHit<T>> hits;
+	
+	public Hits() {}
+
+	public int getTotal() {
+		return total;
+	}
+
+	public void setTotal(int total) {
+		this.total = total;
+	}
+
+	public float getMax_score() {
+		return max_score;
+	}
+
+	public void setMax_score(float max_score) {
+		this.max_score = max_score;
+	}
+
+	public List<SearchHit<T>> getHits() {
+		return hits;
+	}
+
+	public void setHits(List<SearchHit<T>> hits) {
+		this.hits = hits;
+	}
+
+	@Override
+	public String toString() {
+		return "Hits [total=" + total + ", max_score=" + max_score + ", hits="
+				+ hits + "]";
+	}
+}

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/RemoteDataStore.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/RemoteDataStore.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -66,6 +67,33 @@ public class RemoteDataStore implements IDataStore {
 		gson = gb.create();
 	}
 
+
+	@Override
+	public List<Question> getQuestionList() {
+		HttpClient httpClient = new DefaultHttpClient();
+		HttpGet httpGet = new HttpGet(ES_BASE_URL + QUESTION_PATH + "_search");
+
+		HttpResponse response;
+
+		try {
+			response = httpClient.execute(httpGet);
+			@SuppressWarnings("unchecked")
+			SearchResponse<Question> sr = (SearchResponse<Question>) parseESResponse(
+					response, new TypeToken<SearchResponse<Question>>() {
+					}.getType());
+			List<SearchHit<Question>> hits = sr.getHits().getHits();
+			List<Question> result = new ArrayList<Question>();
+			for (SearchHit<Question> hit: hits) {
+				result.add(hit.getSource());
+			}
+			return result;
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		return null;
+	}
+	
 	@Override
 	public void putQuestion(Question question) {
 		HttpClient httpClient = new DefaultHttpClient();
@@ -152,12 +180,6 @@ public class RemoteDataStore implements IDataStore {
 			e.printStackTrace();
 		}
 
-		return null;
-	}
-
-	@Override
-	public List<Question> getQuestionList() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/SearchResponse.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/SearchResponse.java
@@ -1,0 +1,78 @@
+/* This file was written by Victor Guana
+ * See https://github.com/guana/elasticsearch
+ * 
+ * Used with permission
+ */
+package ca.ualberta.cs.cmput301f14t14.questionapp.data;
+
+
+public class SearchResponse<T> {
+
+	private int took;
+	private boolean timed_out;
+	private Shard _shards;
+	private Hits<T> hits;
+	
+	public SearchResponse() {}
+
+	public int getTook() {
+		return took;
+	}
+
+	public void setTook(int took) {
+		this.took = took;
+	}
+
+	public boolean isTimed_out() {
+		return timed_out;
+	}
+
+	public void setTimed_out(boolean timed_out) {
+		this.timed_out = timed_out;
+	}
+
+	public Shard get_shards() {
+		return _shards;
+	}
+
+	public void set_shards(Shard _shards) {
+		this._shards = _shards;
+	}
+
+	public Hits<T> getHits() {
+		return hits;
+	}
+
+	public void setHits(Hits<T> hits) {
+		this.hits = hits;
+	}	   
+}
+
+	
+
+class Shard {
+	private int total;
+	private int successful;
+	private int failed;
+	
+	public Shard() {}
+	
+	public int getTotal() {
+		return total;
+	}
+	public void setTotal(int total) {
+		this.total = total;
+	}
+	public int getSuccessful() {
+		return successful;
+	}
+	public void setSuccessful(int successful) {
+		this.successful = successful;
+	}
+	public int getFailed() {
+		return failed;
+	}
+	public void setFailed(int failed) {
+		this.failed = failed;
+	}
+}

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/AnswerDeserializer.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/AnswerDeserializer.java
@@ -3,11 +3,16 @@ package ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer;
 import java.lang.reflect.Type;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
+import android.content.Context;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.DataManager;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -18,19 +23,40 @@ import com.google.gson.JsonParseException;
  * Class used by GSON to deserialize Answer objects
  */
 public class AnswerDeserializer implements JsonDeserializer<Answer> {
+	private DataManager dm;
+
+	public AnswerDeserializer(Context context) {
+		dm = DataManager.getInstance(context);
+	}
 
 	public Answer deserialize(final JsonElement json, final Type type,
 			final JsonDeserializationContext context) throws JsonParseException {
 		final JsonObject jsonObject = json.getAsJsonObject();
 
 		try {
-			final Answer answer = new Answer();
+			Answer answer;
+			UUID aid = UUID.fromString(jsonObject.get("id").getAsString());
+
+			// Get existing object if available
+			answer = dm.getLocalDataStore().getAnswer(aid);
+			if (answer == null)
+				answer = new Answer();
+
+			// Populate object
 			answer.setId(UUID.fromString(jsonObject.get("id").getAsString()));
 			answer.setBody(jsonObject.get("body").getAsString());
 			answer.setAuthor(jsonObject.get("author").getAsString());
 			answer.setDate(new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US).parse(jsonObject.get("date").getAsString()));
 			answer.setUpvotes(jsonObject.get("upvotes").getAsInt());
-			// TODO: Comments
+
+			// Populate comment list
+			List<UUID> commentList = new ArrayList<UUID>();
+			JsonArray commentJsonArray = jsonObject.getAsJsonArray("comments");
+			for (JsonElement cIdElement: commentJsonArray) {
+				commentList.add(UUID.fromString(cIdElement.getAsString()));
+			}
+			answer.setCommentList(commentList);
+
 			return answer;
 		} catch (ParseException ex) {
 			ex.printStackTrace();

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/QuestionDeserializer.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/model/serializer/QuestionDeserializer.java
@@ -3,11 +3,16 @@ package ca.ualberta.cs.cmput301f14t14.questionapp.model.serializer;
 import java.lang.reflect.Type;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
+import android.content.Context;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.DataManager;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -18,20 +23,48 @@ import com.google.gson.JsonParseException;
  * Class used by GSON to deserialize Question objects
  */
 public class QuestionDeserializer implements JsonDeserializer<Question> {
+	private DataManager dm;
+
+	public QuestionDeserializer(Context context) {
+		dm = DataManager.getInstance(context);
+	}
 
 	public Question deserialize(final JsonElement json, final Type type,
 			final JsonDeserializationContext context) throws JsonParseException {
 		final JsonObject jsonObject = json.getAsJsonObject();
 
 		try {
-			final Question question = new Question();
-			question.setId(UUID.fromString(jsonObject.get("id").getAsString()));
+			Question question;
+			UUID qid = UUID.fromString(jsonObject.get("id").getAsString());
+			
+			// Get existing object if available
+			question = dm.getLocalDataStore().getQuestion(qid);
+			if (question == null)
+				question = new Question();
+			
+			// Populate object
+			question.setId(qid);
 			question.setTitle(jsonObject.get("title").getAsString());
 			question.setBody(jsonObject.get("body").getAsString());
 			question.setAuthor(jsonObject.get("author").getAsString());
 			question.setDate(new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US).parse(jsonObject.get("date").getAsString()));
 			question.setUpvotes(jsonObject.get("upvotes").getAsInt());
-			// TODO: Answers and comments
+			
+			// Populate comment list
+			List<UUID> commentList = new ArrayList<UUID>();
+			JsonArray commentJsonArray = jsonObject.getAsJsonArray("comments");
+			for (JsonElement cIdElement: commentJsonArray) {
+				commentList.add(UUID.fromString(cIdElement.getAsString()));
+			}
+			question.setCommentList(commentList);
+			
+			// Populate answer list
+			List<UUID> answerList = new ArrayList<UUID>();
+			JsonArray answerJsonArray = jsonObject.getAsJsonArray("answers");
+			for (JsonElement aIdElement: answerJsonArray) {
+				answerList.add(UUID.fromString(aIdElement.getAsString()));
+			}
+			question.setAnswerList(answerList);
 			return question;
 		} catch (ParseException ex) {
 			ex.printStackTrace();

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/AnswerTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/AnswerTest.java
@@ -74,12 +74,12 @@ public class AnswerTest extends ActivityInstrumentationTestCase2<MainActivity> {
 	 */
 	
 	public void testLocalAnswerCreate() {
-		manager.addQuestion(mQuestion);
+		manager.addQuestion(mQuestion, null);
 		UUID qId = mQuestion.getId();
 		mQuestion.addAnswer(mAnswer.getId());
 		manager.addAnswer(mAnswer);
 		UUID aId = mAnswer.getId();
-		assertNotNull(manager.getAnswer(aId));
+		assertNotNull(manager.getAnswer(aId, null));
 		
 		remote.putAnswer(mAnswer);
 		remote.putQuestion(mQuestion);

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/CommentTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/CommentTest.java
@@ -98,7 +98,7 @@ public class CommentTest extends ActivityInstrumentationTestCase2<MainActivity> 
 		local.putAComment(secComment);
 		mAnswer.addComment(secComment);
 		UUID secId = mComment.getId();
-		assertNotNull(manager.getAnswerComment(secId));
+		assertNotNull(manager.getAnswerComment(secId, null));
 		remote.putAComment(secComment);
 		remote.putAnswer(mAnswer);
 		assertTrue(mQuestion.hasComment(mComment.getId()));

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/DataManagerTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/DataManagerTest.java
@@ -1,6 +1,5 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.test;
 
-import java.util.Collection;
 import java.util.List;
 
 import android.test.ActivityInstrumentationTestCase2;
@@ -55,7 +54,7 @@ public class DataManagerTest extends ActivityInstrumentationTestCase2<MainActivi
 		manager.setUsername("Different user");
 		assertEquals("Different user", manager.getUsername());
 	}
-	
+
 	public void testGetQuestion(){
 
 		try{

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/QuestionListTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/QuestionListTest.java
@@ -14,7 +14,7 @@ import junit.framework.TestCase;
 public class QuestionListTest extends ActivityInstrumentationTestCase2<MainActivity> {
 
 	private LocalDataStore mLocalStore;
-	public RemoteDataStore mRemoteStore = new RemoteDataStore(getInstrumentation().getTargetContext().getApplicationContext());
+	private RemoteDataStore mRemoteStore;
 
 	private Question mQuestion;
 	private DataManager manager;
@@ -28,6 +28,7 @@ public class QuestionListTest extends ActivityInstrumentationTestCase2<MainActiv
 	protected void setUp() throws Exception {
 		super.setUp();
 		mLocalStore = new LocalDataStore(getInstrumentation().getTargetContext().getApplicationContext());
+		mRemoteStore = new RemoteDataStore(getInstrumentation().getTargetContext().getApplicationContext());
 
 		mQuestion = new Question("TITLE", "BODY", "AUTHOR", null);
 		mAnswer = new Answer(mQuestion.getId(), "ANSWERBODY", "AUTHOR", null);

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/QuestionTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/QuestionTest.java
@@ -111,7 +111,7 @@ public class QuestionTest extends ActivityInstrumentationTestCase2<MainActivity>
 		Question q = new Question(title, body, author, image);
 		local.putQuestion(q);
 		UUID id = q.getId();
-		assertNotNull(manager.getQuestion(id));
+		assertNotNull(manager.getQuestion(id, null));
 		remote.putQuestion(q);
 		assertNotNull(remote.getQuestion(id));
 	}

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/SearchTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/SearchTest.java
@@ -68,10 +68,10 @@ public class SearchTest extends ActivityInstrumentationTestCase2<MainActivity> {
 		List<Answer> resultAnswers = new ArrayList<Answer>();
 		List<Question> resultQuestions = new ArrayList<Question>();
 		for (UUID i : results) {
-			if (manager.getAnswer(i) != null) {
-				resultAnswers.add(manager.getAnswer(i));
+			if (manager.getAnswer(i, null) != null) {
+				resultAnswers.add(manager.getAnswer(i, null));
 			} else {
-				resultQuestions.add(manager.getQuestion(i));
+				resultQuestions.add(manager.getQuestion(i, null));
 			}
 		}
 		assertTrue(resultQuestions.size() > 0 || resultAnswers.size() > 0);

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/data/LocalDataStoreTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/data/LocalDataStoreTest.java
@@ -52,10 +52,8 @@ public class LocalDataStoreTest extends ActivityInstrumentationTestCase2<MainAct
 	}
 	
 	public void testPutAnswer() {
-		assertNull(localStore.getQuestion(new_q.getId()));
 		assertNull(localStore.getAnswer(new_a.getId()));
 		localStore.putAnswer(new_a);
-		assertEquals(new_q, localStore.getQuestion(new_q.getId()));
 		assertEquals(new_a, localStore.getAnswer(new_a.getId()));
 	}
 	

--- a/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/data/RemoteDataStoreTest.java
+++ b/QuestionAppTests/src/ca/ualberta/cs/cmput301f14t14/questionapp/test/data/RemoteDataStoreTest.java
@@ -1,7 +1,11 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.test.data;
 
+import java.util.List;
+
 import android.test.ActivityInstrumentationTestCase2;
 import ca.ualberta.cs.cmput301f14t14.questionapp.MainActivity;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.DataManager;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.LocalDataStore;
 import ca.ualberta.cs.cmput301f14t14.questionapp.data.RemoteDataStore;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
@@ -11,6 +15,7 @@ import ca.ualberta.cs.cmput301f14t14.questionapp.test.mock.MockData;
 public class RemoteDataStoreTest extends
 		ActivityInstrumentationTestCase2<MainActivity> {
 
+	private LocalDataStore localStore;
 	private RemoteDataStore remoteStore;
 
 	public RemoteDataStoreTest() {
@@ -19,7 +24,9 @@ public class RemoteDataStoreTest extends
 
 	protected void setUp() throws Exception {
 		super.setUp();
-		remoteStore = new RemoteDataStore(getInstrumentation().getTargetContext().getApplicationContext());
+		DataManager dm = DataManager.getInstance(getInstrumentation().getTargetContext().getApplicationContext());
+		localStore = (LocalDataStore) dm.getLocalDataStore();
+		remoteStore = (RemoteDataStore) dm.getRemoteDataStore();
 		MockData.initMockData();
 	}
 
@@ -28,9 +35,22 @@ public class RemoteDataStoreTest extends
 	 */
 	public void testPutQuestion() {
 		Question q = MockData.questions.get(0);
+		localStore.putQuestion(q);
 		remoteStore.putQuestion(q);
 		Question retrievedQuestion = remoteStore.getQuestion(q.getId());
 		assertEquals(q, retrievedQuestion);
+	}
+	
+	/**
+	 * Verify that a question list can be fetched from ElasticSearch
+	 */
+	public void testGetQuestionList() {
+		Question q = MockData.questions.get(1);
+		localStore.putQuestion(q);
+		remoteStore.putQuestion(q);
+		List<Question> ql = remoteStore.getQuestionList();
+		assertTrue(ql.size() != 0);
+		assertTrue(ql.contains(q));
 	}
 
 	/**
@@ -38,6 +58,7 @@ public class RemoteDataStoreTest extends
 	 */
 	public void testPutAnswer() {
 		Answer a = MockData.answers.get(0);
+		localStore.putAnswer(a);
 		remoteStore.putAnswer(a);
 		Answer retrievedAnswer = remoteStore.getAnswer(a.getId());
 		assertEquals(a, retrievedAnswer);


### PR DESCRIPTION
This pull request enables getting questions and answers from ES.

The ES parent-child mapping API is extremely disgusting. You cannot access a child directly without knowing its parents' id. Instead, I search for any answer matching the id of the child, which kind of defeats the purpose of this whole mapping mess. (At least it's a reasonable setup for getting all children at once.)

At least it seems to work.

(RemoteDataStore is still disabled via the DataManager)
