### PR TITLE
Increasted type safety on callbacks

### DIFF
--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/Callback.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/Callback.java
@@ -1,6 +1,6 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.data;
 
-public interface Callback {
-	public void run(Object o);  //Super dangerous, but the callback when created should know
+public interface Callback<T> {
+	public void run(T o);  //Super dangerous, but the callback when created should know
 								//What to expect when casting
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
@@ -108,7 +108,7 @@ public class DataManager {
 	}
 	
 	//View Interface Begins
-	public void addQuestion(Question validQ, Callback c) {
+	public void addQuestion(Question validQ, Callback<Void> c) {
 		AddQuestionTask aqt = new AddQuestionTask(this.singletoncontext);
 		aqt.setCallBack(c);
 		aqt.execute(validQ);
@@ -119,7 +119,7 @@ public class DataManager {
 	 * @param id
 	 * @return
 	 */
-	public Question getQuestion(UUID id, Callback c) {
+	public Question getQuestion(UUID id, Callback<Question> c) {
 		//Need to add the question we got into the recentVisit list
 		GetQuestionTask gqt = new GetQuestionTask(singletoncontext);
 		Question qnull = null;
@@ -129,10 +129,9 @@ public class DataManager {
 			//do something evil
 			return gqt.blockingRun(new UUID[]{id});
 		}
-		gqt.setCallBack(new Callback() {
+		gqt.setCallBack(new Callback<Question>() {
 			@Override
-			public void run(Object o) {
-				Question q = (Question) o;
+			public void run(Question q) {
 				recentVisit.add(q.getId());
 			}
 		});
@@ -161,7 +160,7 @@ public class DataManager {
 	 * @param Aid Answer ID
 	 * @return
 	 */
-	public Answer getAnswer(UUID Aid, Callback c) {
+	public Answer getAnswer(UUID Aid, Callback<Answer> c) {
 		//Add this answer to the recentVisit list
 		GetAnswerTask gat = new GetAnswerTask(singletoncontext);
 		Answer anull = null;
@@ -169,10 +168,9 @@ public class DataManager {
 			//User wants an answer within a thread, or doesn't care about blocking.
 			return gat.blockingRun(Aid);
 		}
-		gat.setCallBack(new Callback() {
+		gat.setCallBack(new Callback<Answer>() {
 			@Override
-			public void run(Object o) {
-				Answer a = (Answer)o;
+			public void run(Answer a) {
 				recentVisit.add(a.getId());
 			}
 		});
@@ -199,7 +197,7 @@ public class DataManager {
 	 */
 	//Wtf, when I added a Callback parameter, nothing broke... Is this 
 	//method actually called anywhere in the app?
-	public Comment<Question> getQuestionComment(UUID cid, Callback c) {
+	public Comment<Question> getQuestionComment(UUID cid, Callback<Comment<Question>> c) {
 		GetQuestionCommentTask gqct = new GetQuestionCommentTask(singletoncontext);
 		if (c == null){
 			//User does not care about blocking
@@ -207,12 +205,10 @@ public class DataManager {
 		}
 		//User cares about threading
 		//Add this questionComment to the recentVisit list
-		gqct.setCallBack(new Callback() {
+		gqct.setCallBack(new Callback<Comment<Question>>() {
 			@Override
-			public void run(Object o) {
-				Comment<Question> cq = (Comment<Question>)o; //Yep, this is evil
+			public void run(Comment<Question> cq) {
 				readLater.add(cq.getId());
-				
 			}
 		});
 		gqct.execute(cid);
@@ -240,17 +236,16 @@ public class DataManager {
 	 */
 	//Another case where adding a callback to the function signature didn't break the app
 	//Are we using this?
-	public Comment<Answer> getAnswerComment(UUID Cid, Callback c){
+	public Comment<Answer> getAnswerComment(UUID Cid, Callback<Comment<Answer>> c){
 		GetAnswerCommentTask gact = new GetAnswerCommentTask(singletoncontext);
 		if (c == null) {
 			//User doesn't care about threading and expects this to be blocking.
 			return gact.blockingRun(Cid);
 		}
 		//Need to add this to the recentVisit list.
-		gact.setCallBack(new Callback() {
+		gact.setCallBack(new Callback<Comment<Answer>>() {
 			@Override
-			public void run(Object o) {
-				Comment<Answer> ca = (Comment<Answer>)o; //Yep, more evil casting
+			public void run(Comment<Answer> ca) {
 				recentVisit.add(ca.getId());
 				
 			}
@@ -284,7 +279,7 @@ public class DataManager {
 		return questionList;
 	}
 	//Changing function signature didn't break things. Are we using this?
-	public List<Comment<Answer>> getCommentList(Answer a, Callback c){
+	public List<Comment<Answer>> getCommentList(Answer a, Callback<List<Comment<Answer>>> c){
 		GetCommentListAnsTask gclat = new GetCommentListAnsTask(singletoncontext);
 		if (c == null) {
 			//User doesn't care this is blocking
@@ -297,7 +292,7 @@ public class DataManager {
 	}
 	
 	//Function signature change didn't break things. Are we using this?
-	public List<Comment<Question>> getCommentList(Question q, Callback c){
+	public List<Comment<Question>> getCommentList(Question q, Callback<List<Comment<Question>>> c){
 		GetCommentListQuesTask gclqt = new GetCommentListQuesTask(singletoncontext);
 		if (c == null) {
 			//User doesn't care this is blocking
@@ -309,7 +304,7 @@ public class DataManager {
 		return null;
 	}
 	
-	public List<Answer> getAnswerList(Question q, Callback c){
+	public List<Answer> getAnswerList(Question q, Callback<List<Answer>> c){
 		GetAnswerListTask galt = new GetAnswerListTask(singletoncontext);
 		if (c == null) {
 			//User does not care this is blocking

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AbstractDataManagerTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AbstractDataManagerTask.java
@@ -1,6 +1,7 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.data.threading;
 
 import ca.ualberta.cs.cmput301f14t14.questionapp.data.Callback;
+import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
 import android.content.Context;
 import android.os.AsyncTask;
 
@@ -30,4 +31,11 @@ public abstract class AbstractDataManagerTask<S,T,V> extends AsyncTask<S,T,V> {
 		return this.doInBackground(params);
 	}
 
+	@Override
+	protected void onPostExecute(V v) {
+		if (callback == null) {
+			return;
+		}
+		callback.run(v);
+	}
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AbstractDataManagerTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AbstractDataManagerTask.java
@@ -17,9 +17,9 @@ public abstract class AbstractDataManagerTask<S,T,V> extends AsyncTask<S,T,V> {
 		return context;
 	}
 	
-	Callback callback = null;
+	Callback<V> callback = null;
 	
-	public void setCallBack(Callback c) {
+	public void setCallBack(Callback<V> c) {
 		callback = c;
 	}
 	/** Runs doInBackground in the current thread.

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddQuestionTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddQuestionTask.java
@@ -7,14 +7,14 @@ import ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events.QuestionPu
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
 import android.content.Context;
 
-public class AddQuestionTask extends AbstractDataManagerTask<Question, Void, Boolean>{
+public class AddQuestionTask extends AbstractDataManagerTask<Question, Void, Void>{
 
 	public AddQuestionTask(Context c) {
 		super(c);
 	}
 
 	@Override
-	protected Boolean doInBackground(Question... qin) {
+	protected Void doInBackground(Question... qin) {
 		Question q = qin[0]; // Ignore other questions inputted
 		IDataStore remote = DataManager.getInstance(this.getContext())
 			.getRemoteDataStore();
@@ -22,7 +22,7 @@ public class AddQuestionTask extends AbstractDataManagerTask<Question, Void, Boo
 		if (remote.hasAccess()){
 			remote.putQuestion(q);
 			remote.save();
-			return true;
+			return null;
 		} else {
 			//Put into local data store and don't mark the task as complete
 			IDataStore local = DataManager.getInstance(getContext()).getLocalDataStore();
@@ -31,7 +31,7 @@ public class AddQuestionTask extends AbstractDataManagerTask<Question, Void, Boo
 				local.save();
 			
 			EventBus.getInstance().addEvent(new QuestionPushDelayedEvent(q));
-			return false;
+			return null;
 		}
 		
 	}

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddQuestionTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddQuestionTask.java
@@ -36,12 +36,6 @@ public class AddQuestionTask extends AbstractDataManagerTask<Question, Void, Boo
 		
 	}
 	
-	@Override
-	protected void onPostExecute(Boolean finished) {
-		if (callback == null) {
-			return;
-		}
-		callback.run(finished);
-	}
+
 
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetAnswerCommentTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetAnswerCommentTask.java
@@ -39,13 +39,7 @@ public class GetAnswerCommentTask extends AbstractDataManagerTask<UUID, Void, Co
 	
 	}
 	
-	@Override
-	protected void onPostExecute(Comment<Answer> ca) {
-		if (callback == null){
-			return;
-		}
-		callback.run(ca);
-	}
+
 
 }
 

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetAnswerListTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetAnswerListTask.java
@@ -29,12 +29,6 @@ public class GetAnswerListTask extends AbstractDataManagerTask<Question, Void, L
 		return answers;
 	}
 	
-	@Override
-	protected void onPostExecute(List<Answer> la) {
-		if (callback == null){
-			return;
-		}
-		callback.run(la);
-	}
+
 
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetAnswerTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetAnswerTask.java
@@ -36,12 +36,6 @@ public class GetAnswerTask extends AbstractDataManagerTask<UUID, Void, Answer> {
 	  	return answer;
 	}
 	
-	@Override
-	protected void onPostExecute(Answer a) {
-		if (callback == null) {
-			return;
-		}
-		callback.run(a);
-	}
+
 
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetCommentListAnsTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetCommentListAnsTask.java
@@ -30,11 +30,4 @@ public class GetCommentListAnsTask extends AbstractDataManagerTask<Answer, Void,
 		return comments;
 	}
 
-	@Override
-	protected void onPostExecute(List<Comment<Answer>> lca) {
-		if (callback == null){
-			return;
-		}
-		callback.run(lca);
-	}
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetCommentListQuesTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetCommentListQuesTask.java
@@ -29,12 +29,5 @@ public class GetCommentListQuesTask extends AbstractDataManagerTask<Question, Vo
 		return comments;
 	}
 	
-	@Override
-	protected void onPostExecute(List<Comment<Question>> lcq) {
-		if (callback == null){
-			return;
-		}
-		callback.run(lcq);
-	}
 
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetQuestionCommentTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetQuestionCommentTask.java
@@ -37,12 +37,6 @@ public class GetQuestionCommentTask extends AbstractDataManagerTask<UUID, Void, 
 
 		
 	}
-	@Override
-	protected void onPostExecute(Comment<Question> cq) {
-		if (callback == null){
-			return;
-		}
-		callback.run(cq);
-	}
+
 }
 

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetQuestionTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/GetQuestionTask.java
@@ -34,13 +34,7 @@ public class GetQuestionTask extends AbstractDataManagerTask<UUID, Void, Questio
 	  	return q;
 	}
 	
-	@Override
-	protected void onPostExecute(Question question) {
-		if (callback == null) {
-			return;
-		}
-		callback.run(question);
-	}
+
 	
 
 }


### PR DESCRIPTION
No more willy-nilly casting from Object to your type of choice. Callback is now a parameterized type Callback<T>. DataManager methods now expect a certain type of Callback. Eclipse should now warn you if your types are mismatched (so we don't run into runtime ClassCastExceptions).
