### PR TITLE
UploaderService is now a thing.

### DIFF
--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import android.content.Context;
+import android.content.Intent;
 
 import ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.EventBus;
 import ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events.AbstractEvent;
@@ -22,6 +23,7 @@ import ca.ualberta.cs.cmput301f14t14.questionapp.data.threading.GetCommentListTa
 import ca.ualberta.cs.cmput301f14t14.questionapp.data.threading.GetQuestionCommentTask;
 import ca.ualberta.cs.cmput301f14t14.questionapp.data.threading.GetQuestionListTask;
 import ca.ualberta.cs.cmput301f14t14.questionapp.data.threading.GetQuestionTask;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.threading.UploaderService;
 import ca.ualberta.cs.cmput301f14t14.questionapp.data.threading.UpvoteQuestionTask;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
@@ -76,11 +78,21 @@ public class DataManager {
 		if (instance == null){
 			instance = new DataManager(context.getApplicationContext());
 			instance.initDataStores();
+			
+			
 		}
 		
 		return instance;
 	}
-	
+	/**
+	 * Starts the uploader service that copies cached creations in local to remote.
+	 */
+	private void startUploaderService() {
+		if (UploaderService.isServiceAlreadyRunning == false) {
+			Intent i = new Intent(context, UploaderService.class);
+			context.startService(i);
+		}
+	}
 	
 	
 	//View Interface Begins

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
@@ -78,8 +78,6 @@ public class DataManager {
 		if (instance == null){
 			instance = new DataManager(context.getApplicationContext());
 			instance.initDataStores();
-			
-			
 		}
 		
 		return instance;
@@ -87,7 +85,8 @@ public class DataManager {
 	/**
 	 * Starts the uploader service that copies cached creations in local to remote.
 	 */
-	private void startUploaderService() {
+	public void startUploaderService() {
+		//Hackery. No idea how to start a service only once and not get into threading problems.
 		if (UploaderService.isServiceAlreadyRunning == false) {
 			Intent i = new Intent(context, UploaderService.class);
 			context.startService(i);

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/DataManager.java
@@ -81,37 +81,7 @@ public class DataManager {
 		return instance;
 	}
 	
-	private void completeQueuedEvents() {
-		//The singleton eventbus contains events that attempted to 
-		//be posted to the internet. If posting failed, an event was created
-		//on the eventbus. These queued events should regularly "tried again"
-		//so that we are as frequently as possible trying to update the internet
-		//with our new local information.
-		//I believe this is the magic that is currently missing to make the DataManager
-		//transparently update the local and remote stores.
-		
-		//For each event in the event bus, try and do it again.
-		for (AbstractEvent e: eventbus.getEventQueue()){				
-			/* Remove the current event from the eventbus. If "trying again" fails,
-			 * it will happen in a separate thread, and it will again be added to the bus
-			 */
-			eventbus.removeEvent(e);
-			
-			if (e instanceof QuestionPushDelayedEvent) {
-				//try pushing the question again
-				addQuestion(((QuestionPushDelayedEvent) e).q, null);
-			}
-			if (e instanceof AnswerPushDelayedEvent) {
-				addAnswer(((AnswerPushDelayedEvent) e).a);
-			}
-			if (e instanceof QuestionCommentPushDelayedEvent) {
-				addQuestionComment(((QuestionCommentPushDelayedEvent) e).qc);
-			}
-			if (e instanceof AnswerCommentPushDelayedEvent) {
-				addAnswerComment(((AnswerCommentPushDelayedEvent)e).ca);
-			}
-		}
-	}
+	
 	
 	//View Interface Begins
 	public void addQuestion(Question validQ, Callback<Void> c) {

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/RemoteDataStore.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/RemoteDataStore.java
@@ -411,18 +411,6 @@ public class RemoteDataStore implements IDataStore {
 
 	@Override
 	public boolean hasAccess() {
-		//Needed in UploaderService.
-		//Used code from here: http://www.vogella.com/tutorials/AndroidNetworking/article.html#networkstate
-		
-	    ConnectivityManager cm = (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
-	    	    NetworkInfo networkInfo = cm.getActiveNetworkInfo();
-	    	    // if no network is available networkInfo will be null
-	    	    // otherwise check if we are connected
-	    	    if (networkInfo != null && networkInfo.isConnected()) {
-	    	        return true;
-	    	    }
-	    	    return false;
-		
-		
+		return false;
 	}
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/RemoteDataStore.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/RemoteDataStore.java
@@ -16,6 +16,8 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 
 import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.util.Log;
 
 import com.google.gson.Gson;
@@ -409,7 +411,18 @@ public class RemoteDataStore implements IDataStore {
 
 	@Override
 	public boolean hasAccess() {
-		// TODO Auto-generated method stub
-		return false;
+		//Needed in UploaderService.
+		//Used code from here: http://www.vogella.com/tutorials/AndroidNetworking/article.html#networkstate
+		
+	    ConnectivityManager cm = (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
+	    	    NetworkInfo networkInfo = cm.getActiveNetworkInfo();
+	    	    // if no network is available networkInfo will be null
+	    	    // otherwise check if we are connected
+	    	    if (networkInfo != null && networkInfo.isConnected()) {
+	    	        return true;
+	    	    }
+	    	    return false;
+		
+		
 	}
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/EventBus.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/EventBus.java
@@ -2,6 +2,8 @@ package ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events.AbstractEvent;
 
@@ -9,22 +11,32 @@ public class EventBus {
 	//This is a singleton event bus that contains events.
 	private static final EventBus bus = new EventBus();
 	
+	private AbstractEvent youngestevent = null;
+	
 	public static EventBus getInstance() {
 		return bus;
 	}
 	
 	public void addEvent(AbstractEvent e){
-		queue.add(e);
+		try {
+			queue.put(e);
+			youngestevent = e;
+		} catch (InterruptedException e1) {
+			// queue.put() blocks. However, it could be interrupted.
+			//We don't want Tasks up the good chain to have to deal with this.
+			e1.printStackTrace();
+		}
 	}
 	
-	public void removeEvent(AbstractEvent e) {
-		queue.remove(e);
+	public AbstractEvent getYoungestEvent() {
+		//Get the item last added to the queue
+		return youngestevent;
 	}
 	
-	public List<AbstractEvent> getEventQueue() {
+	public BlockingQueue<AbstractEvent> getEventQueue() {
 		return queue;
 	}
 	
 	//Need a list of events
-	List<AbstractEvent> queue = new ArrayList<AbstractEvent>();
+	BlockingQueue<AbstractEvent> queue = new LinkedBlockingQueue<AbstractEvent>();
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/EventBus.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/EventBus.java
@@ -5,7 +5,10 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import android.content.Intent;
+
 import ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events.AbstractEvent;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.threading.UploaderService;
 
 public class EventBus {
 	//This is a singleton event bus that contains events.
@@ -19,14 +22,7 @@ public class EventBus {
 	
 	public synchronized void addEvent(AbstractEvent e){ 
 		//Need addEvent to be a synchronized event (one thread at a time) because youngestevent
-		//needs to be consistent.
-		
-		
-		//On the note of when to start the uploader service:
-		//If we have gotten to this point, then somewhere in the code an upload failed.
-		//So, we should start the service now.
-		
-		
+		//needs to be consistent.		
 		try {
 			queue.put(e);
 			youngestevent = e;

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/EventBus.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/EventBus.java
@@ -17,7 +17,16 @@ public class EventBus {
 		return bus;
 	}
 	
-	public void addEvent(AbstractEvent e){
+	public synchronized void addEvent(AbstractEvent e){ 
+		//Need addEvent to be a synchronized event (one thread at a time) because youngestevent
+		//needs to be consistent.
+		
+		
+		//On the note of when to start the uploader service:
+		//If we have gotten to this point, then somewhere in the code an upload failed.
+		//So, we should start the service now.
+		
+		
 		try {
 			queue.put(e);
 			youngestevent = e;

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/events/AbstractEvent.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/events/AbstractEvent.java
@@ -1,5 +1,9 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events;
 
+import android.app.Activity;
+import android.app.Application;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.DataManager;
+import android.content.Context;
 public abstract class AbstractEvent {
-
+	public abstract void retry(DataManager dm);
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/events/AnswerCommentPushDelayedEvent.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/events/AnswerCommentPushDelayedEvent.java
@@ -1,5 +1,6 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events;
 
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.DataManager;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
 
@@ -9,6 +10,11 @@ public class AnswerCommentPushDelayedEvent extends AbstractEvent {
 	
 	public AnswerCommentPushDelayedEvent(Comment<Answer> item) {
 		ca = item;
+	}
+
+	@Override
+	public void retry(DataManager dm) {
+		dm.addAnswerComment(ca);
 	}
 	
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/events/AnswerPushDelayedEvent.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/events/AnswerPushDelayedEvent.java
@@ -1,5 +1,6 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events;
 
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.DataManager;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Answer;
 
 public class AnswerPushDelayedEvent extends AbstractEvent {
@@ -8,5 +9,10 @@ public class AnswerPushDelayedEvent extends AbstractEvent {
 	
 	public AnswerPushDelayedEvent(Answer ans) {
 		a = ans;
+	}
+
+	@Override
+	public void retry(DataManager dm) {
+		dm.addAnswer(a);
 	}
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/events/QuestionCommentPushDelayedEvent.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/events/QuestionCommentPushDelayedEvent.java
@@ -1,5 +1,6 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events;
 
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.DataManager;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Comment;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
 
@@ -9,6 +10,11 @@ public class QuestionCommentPushDelayedEvent extends AbstractEvent {
 	
 	public QuestionCommentPushDelayedEvent(Comment<Question> item) {
 		qc = item;
+	}
+
+	@Override
+	public void retry(DataManager dm) {
+		dm.addQuestionComment(qc);
 	}
 
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/events/QuestionPushDelayedEvent.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/eventbus/events/QuestionPushDelayedEvent.java
@@ -1,5 +1,6 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events;
 
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.DataManager;
 import ca.ualberta.cs.cmput301f14t14.questionapp.model.Question;
 
 public class QuestionPushDelayedEvent extends AbstractEvent {
@@ -10,5 +11,11 @@ public class QuestionPushDelayedEvent extends AbstractEvent {
 	public QuestionPushDelayedEvent(Question question) {
 		q = question;
 	}
+
+	@Override
+	public void retry(DataManager dm) {
+		dm.addQuestion(q, null);
+	}
+	
 
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AbstractDataManagerTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AbstractDataManagerTask.java
@@ -1,6 +1,9 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.data.threading;
 
 import ca.ualberta.cs.cmput301f14t14.questionapp.data.Callback;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.DataManager;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.EventBus;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events.AbstractEvent;
 import android.content.Context;
 import android.os.AsyncTask;
 
@@ -47,5 +50,11 @@ public abstract class AbstractDataManagerTask<S,T,V> extends AsyncTask<S,T,V> {
 			return;
 		}
 		callback.run(v);
+	}
+	
+	/* Log the pushDelayed event to the bus, and start the uploader service */
+	protected void tryPushLater(AbstractEvent e) {
+		EventBus.getInstance().addEvent(e);
+		DataManager.getInstance(getContext()).startUploaderService();
 	}
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddAnswerCommentTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddAnswerCommentTask.java
@@ -36,12 +36,12 @@ public class AddAnswerCommentTask extends AbstractDataManagerTask<Comment<Answer
 		try {
 			remoteDataStore.putAComment(C);
 		} catch (IOException e) {
-			EventBus.getInstance().addEvent(new AnswerCommentPushDelayedEvent(C));
+			tryPushLater(new AnswerCommentPushDelayedEvent(C));
 		}
 		try {
 			remoteDataStore.putAnswer(answer);
 		} catch (IOException e) {
-			EventBus.getInstance().addEvent(new AnswerPushDelayedEvent(answer));
+			tryPushLater(new AnswerPushDelayedEvent(answer));
 		}
 		try {
 			localDataStore.putAComment(C);

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddAnswerTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddAnswerTask.java
@@ -37,7 +37,7 @@ public class AddAnswerTask extends AbstractDataManagerTask<Answer, Void, Void>{
 			remote.putAnswer(ans);
 		} catch (IOException e) {
 			Log.d("AddAnswerTask", "Failed to push answer remotely");
-			EventBus.getInstance().addEvent(new AnswerPushDelayedEvent(ans));
+			tryPushLater(new AnswerPushDelayedEvent(ans));
 		}
 		try {
 			local.putAnswer(ans);

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddQuestionCommentTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddQuestionCommentTask.java
@@ -32,7 +32,7 @@ public class AddQuestionCommentTask extends AbstractDataManagerTask<Comment<Ques
 		} catch (IOException e) {
 			Log.e("AddQuestionCommentTask", "Failed to upload question comment");
 			//Push to event bus
-			EventBus.getInstance().addEvent(new QuestionCommentPushDelayedEvent(comment));
+			tryPushLater(new QuestionCommentPushDelayedEvent(comment));
 		}
 		// Push comment to local store
 		try {

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddQuestionTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/AddQuestionTask.java
@@ -25,7 +25,7 @@ public class AddQuestionTask extends AbstractDataManagerTask<Question, Void, Voi
 		try {
 			remote.putQuestion(q);
 		} catch (IOException e) {
-			EventBus.getInstance().addEvent(new QuestionPushDelayedEvent(q));
+			tryPushLater(new QuestionPushDelayedEvent(q));
 		}
 		try {
 			// All questions created by the user should be saved locally

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/UploaderService.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/UploaderService.java
@@ -79,27 +79,11 @@ public class UploaderService extends Service {
 			//For each event in the event bus, try and do it again.
 			for (AbstractEvent e: eventbus.getEventQueue()){				
 				/* Remove the current event from the eventbus. If "trying again" fails,
-				 * it will happen in a separate thread, and it will again be added to the bus
+				 * it will happen in a the AsyncTask threadpool, and it will again be added to the bus
 				 */
 				eventbus.removeEvent(e);
+				e.retry(dm); //dm is from the outer class.
 				
-				//Could get into infinite loop if offline, pop event, try again, re-add before
-				//going online again... etc. Don't want this thread to consume all battery life
-				//while offline.
-				
-				if (e instanceof QuestionPushDelayedEvent) {
-					//try pushing the question again
-					dm.addQuestion(((QuestionPushDelayedEvent) e).q, null);
-				}
-				if (e instanceof AnswerPushDelayedEvent) {
-					dm.addAnswer(((AnswerPushDelayedEvent) e).a);
-				}
-				if (e instanceof QuestionCommentPushDelayedEvent) {
-					dm.addQuestionComment(((QuestionCommentPushDelayedEvent) e).qc);
-				}
-				if (e instanceof AnswerCommentPushDelayedEvent) {
-					dm.addAnswerComment(((AnswerCommentPushDelayedEvent)e).ca);
-				}
 			}
 			
 			// Return number of elements still in queue

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/UploaderService.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/UploaderService.java
@@ -18,6 +18,10 @@ public class UploaderService extends Service {
 	private DataManager dm = null;
 	private Context context = null;
 	
+	//Had to make this static. Little bit of evil hackery to get "singleton"-like behavior.
+	//See DataManager.java:startUploaderService() for the other half of this spaghetti.
+	public static boolean isServiceAlreadyRunning = false;
+	
 	@Override
 	public IBinder onBind(Intent intent) {
 		// This service does not need to communicate with the rest of the app 
@@ -30,6 +34,13 @@ public class UploaderService extends Service {
 		//Set up class variables on creation of service
 		context = getApplicationContext();
 		dm = DataManager.getInstance(context);
+		/* Set */ isServiceAlreadyRunning = true;
+	}
+	
+	@Override
+	public void onDestroy(){
+		//Clean up.
+		isServiceAlreadyRunning = false;
 	}
 	
 	@Override
@@ -37,11 +48,10 @@ public class UploaderService extends Service {
 	    // Flags is useful for services restarted. 
 		// startId is for A unique integer representing this 
 		//    specific request to start. Use with stopSelfResult(int)
+
+
 		
-		//TODO: We should allow this service to be started only once. Allowing multiple things
-		//to start this service is evil. 
-		
-		//Next, we need to create a thread to run completeQueuedEvents in.
+		//We need to create a thread to run completeQueuedEvents in.
 		(new Thread(new QueueClearer())).start();
 		
 	    // We want this service to continue running until it is explicitly

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/UploaderService.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/UploaderService.java
@@ -80,16 +80,15 @@ public class UploaderService extends Service {
 				if (queuesize > 0) {
 					//We've retried what we could, but there are still things left 
 					//in the eventbus that we cannot do. 
-					//This service should sleep until network is restored.
-					while(dm.getRemoteDataStore().hasAccess() == false){
-						try {
+					//It's okay to sleep and simply try again.
 							//Arbitrary sleep time. Could be 1ms, but that would be equivalent to busy-waiting.
-							Thread.sleep(20000); 
-						} catch (InterruptedException e) {
-							/* Not a huge deal if sleeping is interrupted, the EventBus still contains events. */
-							//Therefore, it's okay to do nothing here.
-						}
-					}	
+							try {
+								Thread.sleep(20000);
+							} catch (InterruptedException e) {
+								// It's fine to be interrupted while sleeping.
+							} 
+						
+						
 				} else {
 					//We have cleared out everything in the queue. This service no longer needs to exist.
 					//(The service is recreated in EventBus.addEvent()).

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/UploaderService.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/UploaderService.java
@@ -1,5 +1,82 @@
 package ca.ualberta.cs.cmput301f14t14.questionapp.data.threading;
 
-public class UploaderService {
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.DataManager;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.EventBus;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events.AbstractEvent;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events.AnswerCommentPushDelayedEvent;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events.AnswerPushDelayedEvent;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events.QuestionCommentPushDelayedEvent;
+import ca.ualberta.cs.cmput301f14t14.questionapp.data.eventbus.events.QuestionPushDelayedEvent;
+import android.app.IntentService;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.IBinder;
 
+public class UploaderService extends Service {
+
+	private DataManager dm = null;
+	private Context context = null;
+	
+	@Override
+	public IBinder onBind(Intent intent) {
+		// This service does not need to communicate with the rest of the app 
+		// in our design, so it's okay to return null (according to docs)
+		return null;
+	}
+	
+	@Override
+	public void onCreate() {
+		//Set up class variables on creation of service
+		context = getApplicationContext();
+		dm = DataManager.getInstance(context);
+	}
+	
+	@Override
+	public int onStartCommand(Intent intent, int flags, int startId) {
+	    handleCommand(intent);
+	    // We want this service to continue running until it is explicitly
+	    // stopped, so return sticky.
+	    return START_STICKY;
+	}
+
+	private synchronized void completeQueuedEvents(DataManager dm) {
+		/* The singleton eventbus contains events that attempted to 
+		 * be posted to the internet. If posting failed, an event was created
+		 * on the eventbus. These queued events should regularly "tried again"
+		 * so that we are as frequently as possible trying to update the internet
+		 * with our new local information.
+		 */
+		EventBus eventbus = EventBus.getInstance();
+		//For each event in the event bus, try and do it again.
+		for (AbstractEvent e: eventbus.getEventQueue()){				
+			/* Remove the current event from the eventbus. If "trying again" fails,
+			 * it will happen in a separate thread, and it will again be added to the bus
+			 */
+			eventbus.removeEvent(e);
+			
+			if (e instanceof QuestionPushDelayedEvent) {
+				//try pushing the question again
+				dm.addQuestion(((QuestionPushDelayedEvent) e).q, null);
+			}
+			if (e instanceof AnswerPushDelayedEvent) {
+				dm.addAnswer(((AnswerPushDelayedEvent) e).a);
+			}
+			if (e instanceof QuestionCommentPushDelayedEvent) {
+				dm.addQuestionComment(((QuestionCommentPushDelayedEvent) e).qc);
+			}
+			if (e instanceof AnswerCommentPushDelayedEvent) {
+				dm.addAnswerComment(((AnswerCommentPushDelayedEvent)e).ca);
+			}
+		}
+	}
+
+
+
+
+
+
+
+
+	
 }

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/UploaderService.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/UploaderService.java
@@ -125,7 +125,7 @@ public class UploaderService extends Service {
 			AbstractEvent youngestevent = eventbus.getYoungestEvent();
 			
 			while(!eventbus.getEventQueue().isEmpty() 
-					&& !eventbus.getEventQueue().peek().equals(youngestevent) ){				
+					&& !eventbus.getEventQueue().peek().equals(youngestevent) ){	//Sort circuit logic should prevent .peek() from failing.			
 				try {
 					//Take the event from the head of the queue 
 					//(block this thread if needed), and retry it.

--- a/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/UpvoteQuestionTask.java
+++ b/QuestionApp/src/ca/ualberta/cs/cmput301f14t14/questionapp/data/threading/UpvoteQuestionTask.java
@@ -36,7 +36,7 @@ public class UpvoteQuestionTask extends AbstractDataManagerTask<Question, Void, 
 			//We do not need to have list of "things to upvote online" and "questions
 			// to push online". What actually happens is that the whole question is pushed
 			//again anyways.
-			EventBus.getInstance().addEvent(new QuestionPushDelayedEvent(q));
+			tryPushLater(new QuestionPushDelayedEvent(q));
 		}  
 		//In both cases (online and not), update what we have locally
 		try {


### PR DESCRIPTION
Created a Service. Refactored the completeQueuedTasks() to use polymorphism. Switching on a type was evil, so I created a retry() method in each task. The tasks that need to be retried implement the abstract method.

Little more refactoring in each task so that instead of calling EventBus directly, they call a method in AbstractDataManagerTask to tryPushLater(). This has the effect of calling DataManager.startUploaderService().

Please, don't start UploaderService yourself. I have no idea what happens if two of them are running at once. Use DataManager.startUploaderService() if you really have to (but you shouldn't).

Also, did a bunch of magic with concurrent collections so that it should work. Used a BlockingQueue instead of an ArrayList in the EventBus. Synchronized keywords abound. Also, some neat queue stuff in UploaderService so we don't have an infinite loop trying to upload stuff while offline.

Loads and loads of comments everywhere explaining magic things I think were a good idea at the time :P. 

@stephenjust should look at how I check network connectivity in remoteDataStore using the hasAccess() method. It may make sense to replace what I put in there with a dummy call to ElasticSearch and see if it works.
